### PR TITLE
Rewrite internal IP to external IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM nginx
 
+# python and curl needed in startup.sh
+RUN apt-get update && \
+    apt-get install --no-install-recommends --no-install-suggests -y \
+        python3 \
+        curl
+
 COPY proxy.tmpl /etc/nginx/conf.d/proxy.tmpl
 COPY startup.sh /etc/nginx/startup.sh
 RUN chmod +x /etc/nginx/startup.sh

--- a/proxy.tmpl
+++ b/proxy.tmpl
@@ -3,5 +3,8 @@ server {
     proxy_pass http://${FEDORA_SERVICE_HOST}:${FEDORA_SERVICE_PORT_HTTP};
     auth_basic            "Fedora";
     auth_basic_user_file  /etc/nginx/htpasswd;
+    sub_filter 'http://${FEDORA_SERVICE_HOST}:${FEDORA_SERVICE_PORT_HTTP}' 'http://${NGINX_EXTERNAL_IP}';
+    sub_filter_once off;
+    sub_filter_types text/html application/ld+json application/n-triples application/rdf+xml text/n3 text/rdf+n3 text/plain text/turtle application/x-turtle;
   }
 }

--- a/startup.sh
+++ b/startup.sh
@@ -2,7 +2,20 @@
 set -e
 
 if [ "$1" = 'nginx' ]; then
-  echo "$FEDORA_USER:$FEDORA_PASS" > /etc/nginx/htpasswd
+  TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+  CURL_OPTS=(
+    -s
+    --cacert "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    -H "Authorization: Bearer "${TOKEN}""
+  )
+  PYCODE="import json, sys; \
+    print(json.load(sys.stdin)['status']['loadBalancer']['ingress'][0]['ip'])"
+  export NGINX_EXTERNAL_IP="$(
+    curl "${CURL_OPTS[@]}" \
+      https://kubernetes/api/v1/namespaces/default/services/nginx-proxy |
+    python3 -c "${PYCODE}"
+  )"
+  echo "${FEDORA_USER}:${FEDORA_PASS}" > /etc/nginx/htpasswd
   envsubst < /etc/nginx/conf.d/proxy.tmpl > /etc/nginx/conf.d/default.conf
 fi
 


### PR DESCRIPTION
This adds a rewrite rule to the proxy to fix the links. There's a whole
bunch of nonsense needed to get the external IP of a service from within
a pod. If there's an easier way, it was not apparent.